### PR TITLE
fix `meta/main.yml`'s `not a type of object`

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,4 +11,4 @@ galaxy_info:
   galaxy_tags:
     - aws
 dependencies:
-- baztian.python
+- name: baztian.python


### PR DESCRIPTION
I was running into the same issue where the dependency I had in `meta/main.yml` was listed as "not a type of object". I was able to fix this on my role by prepending `name: ` to the dependency entry.  It was a bear to find this since the ansible documentation examples consistently don't show this. Hope this works for you too, good luck!